### PR TITLE
DES-10308: add FlashTaskBarIcon method to appbridge.js

### DIFF
--- a/symphony/Symphony/appbridge.js
+++ b/symphony/Symphony/appbridge.js
@@ -106,14 +106,16 @@ var appbridge = new function () {
                     args: opts.callbackArg
                 };
             }
+        });
+    };
 
-            // Get the main app window.
-            getMainWindow(function (win) {
-                // Cause the taskbar icon for the window to flash.
-                // -1 --> flash forever
-                // timeout 1500 ms - time between flashes
-                win.drawAttention(true, -1, 1500);
-            });
+    self.FlashTaskbarIcon = function () {
+        // Get the main app window.
+        getMainWindow(function (win) {
+            // Cause the taskbar icon for the window to flash.
+            // -1 --> flash forever
+            // timeout 1500 ms - time between flashes
+            win.drawAttention(true, -1, 1500);
         });
     };
 


### PR DESCRIPTION
provided new appbridge method FlashTaskbarIcon that allows symhony to flashtaskbar icon at will. pulled out of toast notification method so that it can be called whenever a new msg is recvd.
