### PR TITLE
RTC-296 - Wrapper: Canceling the screen share picker should cause a p…

### DIFF
--- a/symphony/Symphony/Plugins/GetWindowsPlugin.cs
+++ b/symphony/Symphony/Plugins/GetWindowsPlugin.cs
@@ -31,7 +31,11 @@ namespace Symphony.Plugins
                 MediaStreamPicker.MediaStreamPickerViewModel vm = new MediaStreamPicker.MediaStreamPickerViewModel(window);
                 window.DataContext = vm;
 
-                EventHandler requestCloseHandler = (sender, args) => window.Close();
+                EventHandler requestCloseHandler = (sender, args) =>
+                {
+                    callback("permission-denied", null);
+                    window.Close();
+                };
                 vm.RequestCancel += requestCloseHandler;
 
                 EventHandler<MediaStreamPicker.RequestShareEventArgs> requestShareHandler = (sender, args) =>


### PR DESCRIPTION
RTC-296 - Wrapper: Canceling the screen share picker should cause a permission denied error
Fixed requestCloseHandler to send permission denied on callback before closing  picker dialog.
