### PR TITLE
RTC-1403 - do not show app picker if OS is Windows 7 with Aero Off

### DIFF
--- a/symphony/Symphony/Plugins/GetWindowsPlugin.cs
+++ b/symphony/Symphony/Plugins/GetWindowsPlugin.cs
@@ -4,6 +4,7 @@ using System;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json;
 using System.Collections.Generic;
+using Symphony.Win32;
 
 namespace Symphony.Plugins
 {
@@ -40,6 +41,19 @@ namespace Symphony.Plugins
                     values.TryGetValue("sources", out sources);
                 }
 
+                //RTC-1403 - do not show app picker if OS is Windows 7.
+                bool aeroEnabled;
+                NativeMethods.DwmIsCompositionEnabled(out aeroEnabled);
+
+                if (System.Environment.OSVersion.Version.Major <= 6 && System.Environment.OSVersion.Version.Minor <= 1 && !aeroEnabled)
+                {
+                    var sourcesList = new List<string>(sources);
+                    if (sourcesList.Contains("window"))
+                    {
+                        sourcesList.RemoveAt(sourcesList.IndexOf("window"));
+                        sources = sourcesList.ToArray();
+                    }
+                }
                 var window = new MediaStreamPicker.MediaStreamPicker(sources);
 
 

--- a/symphony/Symphony/Plugins/GetWindowsPlugin.cs
+++ b/symphony/Symphony/Plugins/GetWindowsPlugin.cs
@@ -41,7 +41,7 @@ namespace Symphony.Plugins
                     values.TryGetValue("sources", out sources);
                 }
 
-                //RTC-1403 - do not show app picker if OS is Windows 7.
+                //RTC-1403 - do not show app picker if OS is Windows 7 & AERO Theme is off.
                 bool aeroEnabled;
                 NativeMethods.DwmIsCompositionEnabled(out aeroEnabled);
 

--- a/symphony/Symphony/Win32/NativeMethods.cs
+++ b/symphony/Symphony/Win32/NativeMethods.cs
@@ -65,6 +65,9 @@ namespace Symphony.Win32
         [DllImport("kernel32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)] 
         public static extern bool CloseHandle(IntPtr hObject);
+
+        [DllImport("dwmapi.dll", EntryPoint = "DwmIsCompositionEnabled")]
+        public static extern int DwmIsCompositionEnabled(out bool enabled);
         
     }
 }


### PR DESCRIPTION
If OS is windows 7 and AERO is turned off, remove "window" from sources list.