### PR TITLE
PLAT-3507: add eikon to protocol whitelist

### DIFF
--- a/symphony/Symphony/manifest.json
+++ b/symphony/Symphony/manifest.json
@@ -18,7 +18,7 @@
     },
     "externalUrlWhitelist": [ "*" ],
 
-    "customProtocolWhitelist" : ["fdsup"],
+    "customProtocolWhitelist" : ["fdsup", "eikon"],
 
     "applicationPlugins": [
         {


### PR DESCRIPTION
adds "eikon" to whitelist to support PLAT-3507 requirements.